### PR TITLE
Add readline method

### DIFF
--- a/asyncserial/asyncserial.py
+++ b/asyncserial/asyncserial.py
@@ -37,7 +37,7 @@ class AsyncSerialBase:
         newline = b'\n'
         data = bytearray()
         while newline not in data:
-            data += await self.read(1)
+            data += await self.read_exactly(1)
         return data
 
 if os.name != "nt":

--- a/asyncserial/asyncserial.py
+++ b/asyncserial/asyncserial.py
@@ -33,10 +33,9 @@ class AsyncSerialBase:
             res = await self.write(data)
             data = data[res:]
 
-    async def readline(self):
-        newline = b'\n'
+    async def readline(self, terminator="\n"):
         data = bytearray()
-        while newline not in data:
+        while terminator not in data:
             data += await self.read_exactly(1)
         return data
 

--- a/asyncserial/asyncserial.py
+++ b/asyncserial/asyncserial.py
@@ -33,7 +33,7 @@ class AsyncSerialBase:
             res = await self.write(data)
             data = data[res:]
 
-    async def readline(self, terminator="\n"):
+    async def readline(self, terminator=b"\n"):
         data = bytearray()
         while terminator not in data:
             data += await self.read_exactly(1)

--- a/asyncserial/asyncserial.py
+++ b/asyncserial/asyncserial.py
@@ -33,6 +33,12 @@ class AsyncSerialBase:
             res = await self.write(data)
             data = data[res:]
 
+    async def readline(self):
+        newline = b'\n'
+        data = bytearray()
+        while newline not in data:
+            data += await self.read(1)
+        return data
 
 if os.name != "nt":
     class AsyncSerial(AsyncSerialBase):


### PR DESCRIPTION
Adds a readline method to the AsyncSerial class interface. Reads an entire 'line' from the serial port character by character until an expected terminator character is read (newline by default). Useful for when a device returns messages of unknown length but with a known terminator.